### PR TITLE
[gatsby-plugin-fastify]: Update README.md

### DIFF
--- a/.changeset/twenty-readers-boil.md
+++ b/.changeset/twenty-readers-boil.md
@@ -1,0 +1,5 @@
+---
+"gatsby-plugin-fastify": patch
+---
+
+chore(gatsby-plugin-fastify): Update README.md

--- a/packages/gatsby-plugin-fastify/README.md
+++ b/packages/gatsby-plugin-fastify/README.md
@@ -94,6 +94,7 @@ All settings may be change via environment variables prefixed with `GATSBY_SERVE
 # For example:
 export GATSBY_SERVER_PORT=3000
 export GATSBY_SERVER_ADDRESS=0.0.0.0
+export GATSBY_SERVER_LOG_LEVEL=debug
 ```
 
 ### Logging


### PR DESCRIPTION
it's not immediately obvious to use `SNAKE_CASE` for `camelCase` CLI option names - might cause some users to wonder why their log level is not changing